### PR TITLE
Develop

### DIFF
--- a/AID-Script-Examples/EWIJSON/.gitignore
+++ b/AID-Script-Examples/EWIJSON/.gitignore
@@ -1,2 +1,3 @@
 data.json
 notes/
+.jsbeautifyrc

--- a/AID-Script-Examples/EWIJSON/release/contextModifier.js
+++ b/AID-Script-Examples/EWIJSON/release/contextModifier.js
@@ -10,6 +10,8 @@ let modifiedText = text.toLowerCase();
 let modifiedContext = context.toLowerCase();
 let memoryLinesLength = memoryLines.length
 
+let copyLines = [...lines];
+let copyMemoryLines = [...memoryLines];
 
 const modifier = (text) =>
 {
@@ -55,10 +57,16 @@ const modifier = (text) =>
         },
         "Check the inserted JSON- lines for the presence of worldEntries keywords.":
         {
-            "req": state.settings["entriesFromJSON"],
+            "req": state.settings["cross"],
             "args": null,
-            "exec": entriesFromJSONLines
+            "exec": crossLines
         },
+       /*  "Add the Stacks":
+        {
+            "req": Stacks,
+            "args": null,
+            "exec": addStacks
+        }, */
         "Create an always visible entry that displays all created roots for Objects.":
         {
             "req": true,

--- a/AID-Script-Examples/EWIJSON/release/contextModifier.js
+++ b/AID-Script-Examples/EWIJSON/release/contextModifier.js
@@ -10,11 +10,9 @@ let modifiedText = text.toLowerCase();
 let modifiedContext = context.toLowerCase();
 let memoryLinesLength = memoryLines.length
 
-// Adjusted and re-created from spliceContext()
-let fullContextLines = [...memoryLines, ...lines];
 
-
-const modifier = (text) => {
+const modifier = (text) =>
+{
     // Position the various attribute tags, push them into temporary lists etc.
     const execute = {
 
@@ -43,29 +41,17 @@ const modifier = (text) => {
             "args": null,
             "exec": getGlobalWhitelist
         },
-        "Push the Objects to sort.":
+        "Sort and execute the Object entries.":
         {
             "req": true,
             "args": null,
             "exec": insertJSON
         },
-        "Push the EWI Attribute entries to sort.":
+        "Sort and execute the EWI Attribute entries.":
         {
             "req": worldEntries.length > 0,
             "args": null,
-            "exec": processWorldEntries
-        },
-        "Sort and process the above by most recent mention.":
-        {
-            "req": true,
-            "args": null,
-            "exec": sortObjects
-        },
-        "Insert Memory Stack":
-        {
-            "req": true,
-            "args": null,
-            "exec": insertMemoryStack
+            "exec": processEWI
         },
         "Check the inserted JSON- lines for the presence of worldEntries keywords.":
         {

--- a/AID-Script-Examples/EWIJSON/release/contextModifier.js
+++ b/AID-Script-Examples/EWIJSON/release/contextModifier.js
@@ -43,13 +43,6 @@ const modifier = (text) => {
             "args": null,
             "exec": getGlobalWhitelist
         },
-        "If an Object is ordered for generation, shift to processing it.":
-        {
-            "req": state.generate.process,
-            "args": text,
-            "exec": generateObject
-        },
-
         "Push the Objects to sort.":
         {
             "req": true,
@@ -95,7 +88,7 @@ const modifier = (text) => {
 
     }
 
-    for (action in execute) { if (execute[action]["req"]) { execute[action]["exec"](execute[action]["args"]) } }
+    for (let action in execute) { if (execute[action]["req"]) { execute[action]["exec"](execute[action]["args"]) } }
 
     let combinedMemory = memoryLines.join('\n')
     let combinedLines = lines.join('\n').slice(-(info.maxChars - combinedMemory.length - 1));

--- a/AID-Script-Examples/EWIJSON/release/contextModifier.js
+++ b/AID-Script-Examples/EWIJSON/release/contextModifier.js
@@ -50,17 +50,29 @@ const modifier = (text) => {
             "exec": generateObject
         },
 
-        "Insert the Objects as JSON- lines.":
+        "Push the Objects to sort.":
         {
             "req": true,
             "args": null,
             "exec": insertJSON
         },
-        "Process the EWI Attribute entries.":
+        "Push the EWI Attribute entries to sort.":
         {
             "req": worldEntries.length > 0,
             "args": null,
             "exec": processWorldEntries
+        },
+        "Sort and process the above by most recent mention.":
+        {
+            "req": true,
+            "args": null,
+            "exec": sortObjects
+        },
+        "Insert Memory Stack":
+        {
+            "req": true,
+            "args": null,
+            "exec": insertMemoryStack
         },
         "Check the inserted JSON- lines for the presence of worldEntries keywords.":
         {
@@ -90,7 +102,7 @@ const modifier = (text) => {
     const finalText = [combinedMemory, combinedLines].join("\n");
 
     // Debug to check if the context is intact and properly utilized, optimally the numbers should always match
-    console.log(`Final Text: ${finalText.length}`, `Max Text: ${info.maxChars}`, `MemoryLength: ${info.memoryLength}`)
+    console.log(`Final Text: ${finalText.length}`, `Max Text: ${info.maxChars}`, `MemoryLength: ${info.memoryLength}`, `Total Memory: ${info.memoryLength + contextMemoryLength}`)
     return { text: finalText }
 
 }

--- a/AID-Script-Examples/EWIJSON/release/shared.js
+++ b/AID-Script-Examples/EWIJSON/release/shared.js
@@ -5,13 +5,25 @@ if (!state.generate) { state.generate = {} }
 if (!state.settings) { state.settings = {} }
 if (!state.settings.globalWhitelist) { state.settings.globalWhitelist = [] }
 // If key (setting[0]) is not in state.settings, initiate it with setting[1] as default value.
-const initSettings = [['entriesFromJSON', true], ['filter', false], ['searchTurnsRange', 4], ['parityMode', false]]
+const initSettings = [
+    ['entriesFromJSON', true],
+    ['filter', false],
+    ['searchTurnsRange', 4],
+    ['parityMode', false]
+]
 initSettings.forEach(setting => { if (!Object.keys(state.settings).includes(setting[0])) { state.settings[setting[0]] = setting[1] } })
 const ewiAttribConfig = ['a', 'd', 'm', 'p', 's', 't']
 
-const invalid = /((("|')[^"']*("|'):)\s*({}|null|"")),?\s*/g;
-const clean = /,\s*(?=})/g;
-const listener = /<l=[^>]*>|<\/l>/g
+// Expressions hold re-usable RegEx.
+const Expressions = {
+
+    "invalid": /((("|')[^"']*("|'):)\s*({}|null|"")),?\s*/g,
+    "clean": /,\s*(?=})/g,
+    "listener": /<l=[^>]*>|<\/l>/g,
+    "placeholder": /\$\{[^{}]*}/g,
+    "attributes": /(\w(=+\d*)?)/g,
+    "split": /=+/
+}
 // Config for consistency.
 state.config = {
     prefix: /^\n> You \/|^\n> You say "\/|^\/|^\n\//gi,
@@ -21,27 +33,28 @@ state.config = {
     synonymsPath: '_synonyms',
     configPath: '_config',
     wildcardPath: '/*',
-    pathSymbol: '.'
+    pathSymbol: '.',
+    openListener: '<l',
+    closeListener: '</l>'
 }
-
-const placeholder = /\$\{[^{}]*}/g
-const openListener = '<l';
-const closeListener = '</l>'
 
 if (!state.settings.ewi) { state.settings.ewi = {} }
 ewiAttribConfig.forEach(attr => { if (!state.settings.ewi.hasOwnProperty(attr)) { state.settings.ewi[attr] = { "range": 4 } } })
 console.log(`Turn: ${info.actionCount}`)
 let { entriesFromJSON } = state.settings;
-const { whitelistPath, synonymsPath, pathSymbol, wildcardPath, configPath, libraryPath } = state.config;
+const { whitelistPath, synonymsPath, pathSymbol, wildcardPath, configPath, libraryPath, openListener, closeListener } = state.config;
 const internalPaths = [whitelistPath, synonymsPath, libraryPath]
 
 // https://www.tutorialspoint.com/group-by-e-in-array-javascript
-const groupElementsBy = arr => {
+const groupElementsBy = arr =>
+{
     const hash = Object.create(null),
         result = [];
-    arr.forEach(el => {
+    arr.forEach(el =>
+    {
         const keys = el.keys.slice(0, el.keys.indexOf('#'))
-        if (!hash[keys]) {
+        if (!hash[keys])
+        {
             hash[keys] = [];
             result.push(hash[keys]);
         };
@@ -50,53 +63,95 @@ const groupElementsBy = arr => {
     return result;
 };
 //https://stackoverflow.com/questions/61681176/json-stringify-replacer-how-to-get-full-path
-const replacerWithPath = (replacer) => { let m = new Map(); return function (field, value) { let path = m.get(this) + (Array.isArray(this) ? `[${field}]` : '.' + field); if (value === Object(value)) m.set(value, path); return replacer.call(this, field, value, path.replace(/undefined\.\.?/, '')); } }
-const worldEntriesFromObject = (obj, root) => { JSON.stringify(obj, replacerWithPath(function (field, value, path) { if (typeof value != 'object') { const index = worldEntries.findIndex(e => e["keys"] == `${root}.${path}`.replace(/^\.*|\.$/g, '')); index >= 0 ? updateWorldEntry(index, `${root}.${path}`.replace(/^\.*|\.$/g, ''), value.toString(), isNotHidden = true) : addWorldEntry(`${root}.${path}`.replace(/^\.*|\.$/g, ''), value.toString(), isNotHidden = true); } return value; })); }
+const replacerWithPath = (replacer) => { let m = new Map(); return function(field, value) { let path = m.get(this) + (Array.isArray(this) ? `[${field}]` : '.' + field); if (value === Object(value)) m.set(value, path); return replacer.call(this, field, value, path.replace(/undefined\.\.?/, '')); } }
+const worldEntriesFromObject = (obj, root) =>
+{
+    JSON.stringify(obj, replacerWithPath(function(field, value, path)
+    {
+        if (typeof value != 'object')
+        {
+            const index = worldEntries.findIndex(e => e["keys"] == `${root}.${path}`.replace(/^\.*|\.$/g, ''));
+            index >= 0 ? updateWorldEntry(index, `${root}.${path}`.replace(/^\.*|\.$/g, ''), value.toString(), isNotHidden = true) : addWorldEntry(`${root}.${path}`.replace(/^\.*|\.$/g, ''), value.toString(), isNotHidden = true);
+        }
+        return value;
+    }));
+}
 //https://stackoverflow.com/questions/273789/is-there-a-version-of-javascripts-string-indexof-that-allows-for-regular-expr#273810
-String.prototype.regexLastIndexOf = function (regex, startpos) { regex = (regex.global) ? regex : new RegExp(regex.source, "g" + (regex.ignoreCase ? "i" : "") + (regex.multiLine ? "m" : "")); if (typeof (startpos) == "undefined") { startpos = this.length; } else if (startpos < 0) { startpos = 0; } let stringToWorkWith = this.substring(0, startpos + 1); let lastIndexOf = -1; let nextStop = 0; while ((result = regex.exec(stringToWorkWith)) != null) { lastIndexOf = result.index; regex.lastIndex = ++nextStop; } return lastIndexOf; }
+String.prototype.regexLastIndexOf = function(regex, startpos)
+{
+    regex = (regex.global) ? regex : new RegExp(regex.source, "g" + (regex.ignoreCase ? "i" : "") + (regex.multiLine ? "m" : ""));
+    if (typeof(startpos) == "undefined") { startpos = this.length; }
+    else if (startpos < 0) { startpos = 0; }
+    let stringToWorkWith = this.substring(0, startpos + 1);
+    let lastIndexOf = -1;
+    let nextStop = 0;
+    while ((result = regex.exec(stringToWorkWith)) != null)
+    {
+        lastIndexOf = result.index;
+        regex.lastIndex = ++nextStop;
+    }
+    return lastIndexOf;
+}
 const getHistoryString = (turns) => history.slice(turns).map(e => e["text"]).join(' ') // Returns a single string of the text.
 const getHistoryText = (turns) => history.slice(turns).map(e => e["text"]) // Returns an array of text.
 const getActionTypes = (turns) => history.slice(turns).map(e => e["type"]) // Returns the action types of the previous turns in an array.
 
 // Ensure that '_synonyms' is processed first in the loop. It's executed if (Object.keys(dataStorage)[0] != synonymsPath)
-// NOTE: Could have unintended side effects of the re-assignment. If it causes issues, check if this can be reworked.
-const fixOrder = () => { dataStorage = Object.assign({ "_whitelist": {}, "_synonyms": {} }, dataStorage); state.data = dataStorage }
-const regExMatch = (expressions, string) => {
-    if (typeof expressions != 'string') { console.log(`Invalid Expressions: ${expressions}`); return }
-    const result = [];
-    const attributes = /#/;
+const fixOrder = () =>
+{
+    dataStorage = Object.assign({ "_whitelist": {}, "_synonyms": {} }, dataStorage);
+    state.data = dataStorage
+}
+const regExMatch = (keys) =>
+{
+    if (typeof keys != 'string') { console.log(`Invalid Expressions: ${keys}`); return }
     // Test the multi-lines individually, last/bottom line qualifying becomes result.
-    const lines = expressions.split(/\n/g);
-    try {
-        lines.forEach(line => {
-            // Construct a pair of [0] expressions and [1] meta-info.
-            const pairs = [line.slice(0, attributes.test(line) ? line.lastIndexOf('#') : line.length).split(/(?<!\\),/g), attributes.test(line) ? line.slice(line.lastIndexOf('#') + 1) : ""];
-            if (pairs[0].every(exp => {
-                const regEx = new RegExp(exp.replace(/\\/g, ''), 'i');
-                return regEx.test(string)
-            })) {
-                result.push([[...string.matchAll(new RegExp(pairs[0].pop(), 'gi'))].filter(Boolean).pop(), Boolean(pairs[1]) ? pairs[1].match(/(\w(=\d*)?)/gi).map(e => e.split('=')) : []])
+    const array = keys.split(/\n/g);
+    const result = [];
+    let key = '';
+    try
+    {
+        array.forEach(line =>
+        {
+
+            const length = getAttributes(line.slice(/#\[.*\]/.test(line) ? line.lastIndexOf('#') : 0)).find(e => e[0] == 'l')
+            const string = lines.slice(length ? -length[1] : 0).join('\n');
+            const expressions = line.slice(0, /#\[.*\]/.test(line) ? line.lastIndexOf('#') : line.length).split(/(?<!\\),/g);
+            if (expressions.every(exp => { const regEx = new RegExp(exp.replace(/\\/g, ''), 'i'); return regEx.test(string); }))
+            {
+                key = line;
+                result.push([...string.matchAll(new RegExp(expressions.pop(), 'gi'))].filter(Boolean).pop());
             }
         })
     }
-    catch (error) { console.log(`An invalid RegEx was detected!\n${error.name}: ${error.message}`); state.message = `An invalid RegEx was detected!\n${error.name}: ${error.message}` }
-    return result.pop()
+    catch (error)
+    {
+        console.log(`An invalid RegEx was detected!\n${error.name}: ${error.message}`);
+        state.message = `An invalid RegEx was detected!\n${error.name}: ${error.message}`
+    }
+    return [result.pop(), key]
 }
+
+const getAttributes = (string) => string.match(Expressions["attributes"]).map(e => e.includes('=') ? e.split(Expressions["split"]) : [e, 0])
 const lens = (obj, path) => path.split('.').reduce((o, key) => o && o[key] ? o[key] : null, obj);
 const replaceLast = (x, y, z) => { let a = x.split(""); let length = y.length; if (x.lastIndexOf(y) != -1) { for (let i = x.lastIndexOf(y); i < x.lastIndexOf(y) + length; i++) { if (i == x.lastIndexOf(y)) { a[i] = z; } else { delete a[i]; } } } return a.join(""); }
 const getMemory = (text) => { return info.memoryLength ? text.slice(0, info.memoryLength) : '' } // If memoryLength is set then slice of the beginning until the end of memoryLength, else return an empty string.
 const getContext = (text) => { return info.memoryLength ? text.slice(info.memoryLength) : text } // If memoryLength is set then slice from the end of memory to the end of text, else return the entire text.
 
 // Extract the last cluster in the RegEx' AND check then filter out non-word/non-whitespace symbols to TRY and assemble the intended words.
-const addDescription = (entry, value = 0) => {
+const addDescription = (entry, value = 0) =>
+{
     const range = entryFunctions['d']['range'];
     const result = entry["keys"].pop()
     let search = lines.slice(-range).join('\n');
     // Find a match for the last expression and grab the most recent word for positioning. Filter out undefined/false values.
-    if (search.includes(result) && result && !Boolean(value)) {
+    if (search.includes(result) && result && !Boolean(value))
+    {
         search = search.slice(0, search.toLowerCase().lastIndexOf(result.toLowerCase())) + result.slice(0, -result.length) + entry["entry"] + ' ' + (result) + search.slice(search.toLowerCase().lastIndexOf(result.toLowerCase()) + result.length)
         lines = search.split('\n');
-    } else if (search.includes(result) && result && Boolean(value)) {
+    }
+    else if (search.includes(result) && result && Boolean(value))
+    {
         search = search.slice(0, search.toLowerCase().lastIndexOf(result.toLowerCase()) + result.length) + ' ' + entry["entry"] + search.slice(search.toLowerCase().lastIndexOf(result.toLowerCase()) + result.length)
         lines = search.split('\n');
     }
@@ -104,51 +159,57 @@ const addDescription = (entry, value = 0) => {
 
 const addAuthorsNote = (entry, value = 0) => state.memory.authorsNote = `${entry["entry"]}`
 const showWorldEntry = (entry, value = 0) => entry.isNotHidden = true
-const addPositionalEntry = (entry, value = 0) => {
+const addPositionalEntry = (entry, value = 0) =>
+{
     const range = entryFunctions['p']['range'];
     const result = entry["keys"][0];
     if (lines.slice(-range).join('\n').includes(result)) { spliceContext((Boolean(value) ? -(value) : lines.length), entry["entry"]) }
 }
 
-const addMemoryEntry = (entry, value = 0) => {
+const addMemoryEntry = (entry, value = 0) =>
+{
     const range = entryFunctions['m']['range'];
     const result = entry["keys"][0];
-    if ( (info.memoryLength + contextMemoryLength + entry["entry"].length) < (info.maxChars/2) && lines.slice(-range).join('\n').includes(result)) 
-    { 
+    if ((info.memoryLength + contextMemoryLength + entry["entry"].length) < (info.maxChars / 2) && lines.slice(-range).join('\n').includes(result))
+    {
         contextMemoryLength += entry["entry"].length
-        memoryStack.push([Boolean(value) ? -(value) : memoryLines.length, entry["entry"]]) 
+        memoryStack.push([Boolean(value) ? -(value) : memoryLines.length, entry["entry"]])
     }
 
 }
-const addTrailingEntry = (entry, value = 0) => {
+const addTrailingEntry = (entry, value = 0) =>
+{
 
     const range = entryFunctions['t']['range'];
     const result = entry["keys"][0];
 
     let finalIndex = -1;
     lines.slice(-range).forEach((line, i) => { if (line.includes(result)) { finalIndex = i; } })
-    if (finalIndex >= 0) {
+    if (finalIndex >= 0)
+    {
         spliceContext((finalIndex) - value, entry["entry"])
     }
     return;
 }
 
-const getWhitelist = () => dataStorage.hasOwnProperty(whitelistPath) && typeof dataStorage[whitelistPath] == 'string' ? dataStorage[whitelistPath].toLowerCase().split(/,|\n/g).map(e => e.trim()) : []
+const getWhitelist = () => { const index = getEntryIndex('_whitelist.'); return index >= 0 ? worldEntries[index]["entry"].toLowerCase().split(/,|\n/g).map(e => e.trim()) : [] }
 const getWildcard = (display, offset = 0) => { const wildcard = display.split('.').slice(offset != 0 ? 0 : 1).join('.'); const list = display.split('.'); const index = list.indexOf(wildcard.slice(wildcard.lastIndexOf('.') + 1)); return [list[index].replace(wildcardPath, ''), index + offset] }
-const getPlaceholder = (value) => typeof value == 'string' ? value.replace(placeholder, match => dataStorage[libraryPath][match.replace(/\$\{|\}/g, '')]) : value
-const updateListener = (value, search, display, visited) => {
+const getPlaceholder = (value) => typeof value == 'string' ? value.replace(Expressions["placeholder"], match => dataStorage[libraryPath][match.replace(/\$\{|\}/g, '')]) : value
+const updateListener = (value, search, display, visited) =>
+{
     // Check if it has previously qualified in 'visited' instead of running regExMatch on each node.
     const qualified = visited.some(e => e.includes(display.split('.')[0]));
-    if (qualified) {
+    if (qualified)
+    {
         const array = value.split(/(?<!\\),/g)
-        const result = array.map(e => {
+        const result = array.map(e =>
+        {
             const find = e.match(/(?<=<l=)[^>]*(?=>)/g)
-            if (find) {
+            if (find)
+            {
                 const expression = getPlaceholder(find[0])
-                const match = regExMatch(`${expression}`, search)
-                if (match) {
-                    return e.replace(/(?<=>)[^<]*(?=<)/g, match[0][0])
-                }
+                const match = regExMatch(`${expression}`)
+                if (match) { return e.replace(/(?<=>)[^<]*(?=<)/g, match[0][0]) }
                 else { return e }
 
             }
@@ -163,25 +224,28 @@ const updateListener = (value, search, display, visited) => {
 
     }
 }
-const globalReplacer = () => {
+const globalReplacer = () =>
+{
 
+    const paths = [];
     const search = lines.join('\n')
     // Toggle the wildcard state to search down full path.
     // If the current path does not include the wildcard path, toggle it to false.
     let wildcards = [];
     const visited = [];
-    const whitelist = getWhitelist().map(e => {
-        if (e.includes(wildcardPath)) {
-            wildcards.push(getWildcard(e, 1));
-            return e.replace(wildcardPath, '')
-        } else {
-            return e.split('.')
-        }
+    const whitelist = getWhitelist().map(e =>
+    {
+        if (e.includes(wildcardPath)) { wildcards.push(getWildcard(e, 1)); return e.replace(wildcardPath, ''); }
+        else { return e.split('.') }
     }).flat();
+
+
     //console.log(`Wildcards: ${wildcards}`)
-    function replacer(replace) {
+    function replacer(replace)
+    {
         let m = new Map();
-        return function (key, value) {
+        return function(key, value)
+        {
             let path = m.get(this) + (Array.isArray(this) ? `[${key}]` : '.' + key);
             let display = path.replace(/undefined\.\.?/, '')
             const root = display.split('.')[0]
@@ -189,55 +253,45 @@ const globalReplacer = () => {
             // Find and store whether the Object qualifies to avoid repeated calls to regExMatch.
             // Without this, it'll call regExMatch for each node. While with this one may run:
             // visited.some(e => e.includes(node))
-            if (dataStorage.hasOwnProperty(root) && dataStorage[root].hasOwnProperty(synonymsPath) && !visited.some(e => e[0].includes(root))) {
-                const match = regExMatch(getPlaceholder(dataStorage[root][synonymsPath]), search)
+            if (dataStorage.hasOwnProperty(root) && dataStorage[root].hasOwnProperty(synonymsPath) && !visited.some(e => e[0].includes(root)))
+            {
+                const match = regExMatch(getPlaceholder(dataStorage[root][synonymsPath]))
                 if (match) { visited.push([root, match[0][0]]) }
             }
 
-            if (value === Object(value)) {
-                m.set(value, path);
-            }
+            if (value === Object(value)) { m.set(value, path); }
+
             const final = replace.call(this, key, value, display);
             let current;
+
             // If the key is in the _whitelist, then implicitly push it.
-            if (Boolean(key) && (whitelist.includes(key))) {
-                paths.push(key)
-                if (typeof value == 'string' && value.includes(closeListener)) {
-                    updateListener(value, search, display, visited);
-                }
+            if (Boolean(key) && (whitelist.includes(key)))
+            {
+                paths.push(key);
+                if (typeof value == 'string' && value.includes(closeListener)) { updateListener(value, search, display, visited); }
             }
-            else if (typeof value == 'string') {
+
+            else if (typeof value == 'string')
+            {
                 // Only match paths in `_synonyms`.
-                const match = display.startsWith(synonymsPath) ? regExMatch(getPlaceholder(value), search) : undefined;
+                const match = display.startsWith(synonymsPath) ? regExMatch(getPlaceholder(value)) : undefined;
                 if (value.includes(closeListener)) { updateListener(value, search, display, visited); }
                 // Key is a wildcard and its value qualifies the regEx match.
-                if (key.includes(wildcardPath) && Boolean(value) && match) {
-                    wildcards.push(getWildcard(display))
-                }
-
+                if (key.includes(wildcardPath) && Boolean(value) && Boolean(match[0])) { wildcards.push(getWildcard(display)) }
                 // The current path contains one of the wildcards.
-                else if (wildcards.some(e => {
-                    if (display.split('.')[e[1]] == e[0]) {
-                        current = e[0];
-                        return true
-                    }
-                })) {
-                    const array = display.split('.')
-                    paths.push(array)
-
-                } else if (display.startsWith(synonymsPath) && Boolean(value) && match) {
-                    paths.push(display.split('.'));
+                else if (wildcards.some(e => { if (display.split('.')[e[1]] == e[0]) { current = e[0]; return true } }))
+                {
+                    const array = display.split('.');
+                    paths.push(array);
                 }
+                else if (display.startsWith(synonymsPath) && Boolean(value) && Boolean(match[0])) { paths.push(display.split('.')); }
 
             }
             return final;
         }
     }
 
-    const paths = [];
-    JSON.stringify(dataStorage, replacer(function (key, value, path) {
-        return value;
-    }));
+    JSON.stringify(dataStorage, replacer(function(key, value, path) { return value; }));
     return [...new Set([...whitelist, ...paths.flat()])].filter(e => !internalPaths.includes(e)).map(e => e.replace(wildcardPath, ''))
 }
 
@@ -246,14 +300,18 @@ const getGlobalWhitelist = () => state.settings.globalWhitelist = globalReplacer
 const setProperty = (keys, value, obj) => { const property = keys.split('.').pop(); const path = keys.split('.')[1] ? keys.split('.').slice(0, -1).join('.') : keys.replace('.', ''); if (property[1]) { getKey(path, obj)[property] = value ? value : null; } else { dataStorage[path] = value; } }
 const getKey = (keys, obj) => { return keys.split('.').reduce((a, b) => { if (typeof a[b] != "object" || a[b] == null) { a[b] = {} } if (!a.hasOwnProperty(b)) { a[b] = {} } return a && a[b] }, obj) }
 
-const buildObjects = () => {
+const buildObjects = () =>
+{
 
     // Consume and process entries whose keys start with '!' or contains '.' and does not contain a '#'.
     const regEx = /(^!|\.)(?!.*#)/
-    worldEntries.filter(wEntry => regEx.test(wEntry["keys"])).forEach(wEntry => {
-        if (wEntry["keys"].startsWith('!')) {
+    worldEntries.filter(wEntry => regEx.test(wEntry["keys"])).forEach(wEntry =>
+    {
+        if (wEntry["keys"].startsWith('!'))
+        {
             const root = wEntry["keys"].match(/(?<=!)[^.]*/)[0];
-            try {
+            try
+            {
                 // Parse the contents into an Object.
                 const object = JSON.parse(wEntry["entry"].match(/{.*}/)[0]);
                 // Remove the parsed entry to prevent further executions of this process.
@@ -264,7 +322,11 @@ const buildObjects = () => {
                 state.message = `Built Objects from !${root}.`
                 worldEntries.filter(e => e["keys"].split('.')[0] == root).forEach(wEntry => setProperty(wEntry["keys"].toLowerCase().split(',').filter(e => e.includes('.')).map(e => e.trim()).join(''), wEntry["entry"], dataStorage))
             }
-            catch (error) { console.log(error); state.message = `Failed to parse implicit conversion of !${root}. Verify the entry's format!` }
+            catch (error)
+            {
+                console.log(error);
+                state.message = `Failed to parse implicit conversion of !${root}. Verify the entry's format!`
+            }
         }
         else { setProperty(wEntry["keys"].toLowerCase().split(',').filter(e => e.includes('.')).map(e => e.trim()).join(''), wEntry["entry"], dataStorage); }
 
@@ -275,53 +337,73 @@ const sanitizeWhitelist = () => { const index = worldEntries.findIndex(e => e["k
 const trackRoots = () => { const list = Object.keys(dataStorage); const index = worldEntries.findIndex(e => e["keys"] == 'rootList'); if (index < 0) { addWorldEntry('rootList', list, isNotHidden = true) } else { updateWorldEntry(index, 'rootList', list, isNotHidden = true) } }
 // Close opened brackets for the string before attempting to JSON.parse() it - slight increase to success rate.
 const getDepth = (string) => { const opened = string.match(/{/g); const closed = string.match(/}/g); return (opened ? opened.length : 0) - (closed ? closed.length : 0) }
-const fixDepth = (string) => { let count = getDepth(string); while (count > 0) { count--; string += `}`; } return string }
+const fixDepth = (string) =>
+{
+    let count = getDepth(string);
+    while (count > 0)
+    {
+        count--;
+        string += `}`;
+    }
+    return string
+}
 
 // TODO: If AND/OR segments are present, only map those that qualify.
 const getRootSynonyms = (root) => dataStorage[root].hasOwnProperty(synonymsPath) ? dataStorage[root][synonymsPath].split(',').map(e => e.toLowerCase().trim()) : []
 
 // spliceContext takes a position to insert a line into the full context (memoryLines and lines combined) then reconstructs it with 'memory' taking priority.
 // TODO: Sanitize and add counter, verify whether memory having priority is detrimental to the structure - 'Remember' should never be at risk of ommitance.
-const spliceContext = (pos, string) => {
+const spliceContext = (pos, string) =>
+{
 
     const linesLength = lines.join('\n').length
     const memoryLength = memoryLines.join('\n').length
 
     let adjustedLines = 0;
-    if ((linesLength + memoryLength) + string.length > info.maxChars) { const adjustor = lines.join('\n').slice(string.length).split('\n'); adjustedLines = lines.length - adjustor.length; lines = adjustor; }
+    if ((linesLength + memoryLength) + string.length > info.maxChars)
+    {
+        const adjustor = lines.join('\n').slice(string.length).split('\n');
+        adjustedLines = lines.length - adjustor.length;
+        lines = adjustor;
+    }
     lines.splice(pos - adjustedLines, 0, string)
     return
 }
 
 const memoryStack = [];
 const insertMemoryStack = () => memoryStack.forEach(e => spliceMemory(e[0], e[1]));
-const spliceMemory = (pos, string) => {
-    
-    
+const spliceMemory = (pos, string) =>
+{
+
+
     contextMemoryLength += string.length;
     memoryLines.splice(pos, 0, string);
     return
 
 }
 
-const cleanString = (string) => string.replace(/\\/g, '').replace(listener, '').replace(invalid, '').replace(clean, '');
+const cleanString = (string) => string.replace(/\\/g, '').replace(Expressions["listener"], '').replace(Expressions["invalid"], '').replace(Expressions["clean"], '');
 //[tavern|inn, Keysworth, tavern-keeper|tavernkeeper], [${obj}, look|watch|spectate, hair]
 
 // TODO: Get the sprawler into a functional state, but that depends on supplimental functions such as 'getRootSynonyms' and the 'globalReplacer'.
 // For parity: 'globalReplacer' might need to be shifted out with a local one and processed on each individual Object as search-length within context will vary depending on float and the blockers in RegEx.
-const insertJSON = () => {
+const insertJSON = () =>
+{
 
     // Cleanup edge-cases of empty Objects in the presented string.
     const { globalWhitelist } = state.settings;
     console.log(`Global Whitelist: ${globalWhitelist}`)
-    for (const data in dataStorage) {
+    for (const data in dataStorage)
+    {
 
-        if (typeof dataStorage[data] == 'object') {
+        if (typeof dataStorage[data] == 'object')
+        {
             if (!dataStorage[data].hasOwnProperty(synonymsPath)) { dataStorage[data][synonymsPath] = `${data}#[t]` }
             let string = cleanString(JSON.stringify(dataStorage[data], globalWhitelist));
             if (state.settings["filter"]) { string = string.replace(/"|{|}/g, ''); }
 
-            if (string.length > 4) {
+            if (string.length > 4)
+            {
                 const object = { "keys": dataStorage[data][synonymsPath].split('\n').map(e => !e.includes('#') ? e + '#[t]' : e).join('\n'), "entry": `[${string}]` }
                 sortList.push(object)
             }
@@ -333,31 +415,37 @@ const insertJSON = () => {
 const entryFunctions = {
     'a': { "func": addAuthorsNote, "range": state.settings.ewi['a'] }, // [a] adds it as authorsNote, only one authorsNote at a time.
     's': { "func": showWorldEntry, "range": state.settings.ewi['s'] }, // [r] reveals the entry once mentioned, used in conjuction with [e] to only reveal if all keywords are mentioned at once.
-    'e': () => { }, // [e] tells the custom keyword check to only run the above functions if every keyword of the entry matches.
+    'e': () => {}, // [e] tells the custom keyword check to only run the above functions if every keyword of the entry matches.
     'd': { "func": addDescription, "range": state.settings.ewi['d'] }, // [d] adds the first sentence of the entry as a short, parenthesized descriptor to the last mention of the revelant keyword(s) e.g John (a business man)
-    'r': () => { }, // [r] picks randomly between entries with the same matching keys. e.g 'you.*catch#[rp=1]' and 'you.*catch#[rd]' has 50% each to be picked.
+    'r': () => {}, // [r] picks randomly between entries with the same matching keys. e.g 'you.*catch#[rp=1]' and 'you.*catch#[rd]' has 50% each to be picked.
     'm': { "func": addMemoryEntry, "range": state.settings.ewi['m'] },
     'p': { "func": addPositionalEntry, "range": state.settings.ewi['p'] }, // Inserts the <entry> <value> amount of lines into context, e.g [p=1] inserts it one line into context.
-    'w': () => { }, // [w] assigns the weight attribute, the higher value the more recent/relevant it will be in context/frontMemory/intermediateMemory etc.
+    'w': () => {}, // [w] assigns the weight attribute, the higher value the more recent/relevant it will be in context/frontMemory/intermediateMemory etc.
     't': { "func": addTrailingEntry, "range": state.settings.ewi['t'] } // [t] adds the entry at a line relative to the activator in context. [t=2] will trail context two lines behind the activating word.
 }
 // A master list that is used for sorting before processing entries.
 const sortList = []
-const pickRandom = () => {
+const pickRandom = () =>
+{
     const lists = groupElementsBy(worldEntries.filter(e => /#.*\[.*r.*\]/.test(e.keys)));
     const result = [worldEntries.filter(e => !/#.*\[.*r.*\]/.test(e.keys))];
     lists.forEach(e => result.push(e[Math.floor(Math.random() * e.length)]))
     return result.flat()
 }
-const processWorldEntries = () => {
+const processWorldEntries = () =>
+{
     const entries = pickRandom(); // Ensure unique assortment of entries that adhere to the [r] attribute if present.
     entries.filter(e => e["keys"].includes('#')).forEach(wEntry => sortList.push(wEntry));
 }
 
-const execAttributes = (keys, entry, attributes) => {
+const execAttributes = (keys, entry, attributes) =>
+{
+    console.log(`ATTRIBUTES: ${attributes}`)
     const array = Boolean(attributes) ? attributes.filter(e => entryFunctions[e[0]].hasOwnProperty('func')) : [];
-    if (array.length > 0) {
-        try {
+    if (array.length > 0)
+    {
+        try
+        {
             array.forEach(pair => { entryFunctions[pair[0]]["func"]({ "keys": keys, "entry": entry }, pair[1]) })
         }
         catch (error) { console.log(`${error.name}: ${error.message}`) }
@@ -366,78 +454,83 @@ const execAttributes = (keys, entry, attributes) => {
 
 // Sort all Objects/entries by the order of most-recent mention before processing.
 // expects sortList to be populated by Objects with properties {"key": string, "entry": string}
-const sortObjects = () => {
+const sortObjects = () =>
+{
     const search = lines.join('\n')
-    sortList.map(e => {
-        const match = regExMatch(getPlaceholder(e["keys"]), search);
-        if (Boolean(match)) {
-            return [search.lastIndexOf(match[0].length > 1 ? match[0].pop() : match[0]), match, e["entry"]];
-        }
-    })
-        .filter(Boolean)
-        .sort((a, b) => b[0] - a[0])
-        .map(e => { return [e[1], e[2]] })
-        .forEach(e => execAttributes(e[0][0], e[1], e[0][1]))
+    sortList.map(e =>
+        {
+            const match = regExMatch(getPlaceholder(e["keys"]));
+            console.log(`SORT OBJECTS MATCH: ${match}`)
+            if (Boolean(match[0]))
+            {
+                return [search.lastIndexOf(match.length > 1 ? match[0].pop() : match), match, e["entry"]];
+            }
+        })
+    .filter(Boolean)
+    .sort((a, b) => b[0] - a[0])
+    .map(e => { return [e[1], e[2]] })
+    .forEach(e => execAttributes(e[0][0], e[1], /#\[.*\]/.test(e[0][1]) ? getAttributes(e[0][1].slice(e[0][1].lastIndexOf('#'))) : []))
 }
 
-const entriesFromJSONLines = () => {
+const entriesFromJSONLines = () =>
+{
     const JSONLines = lines.filter(line => /\[\{.*\}\]/.test(line));
     const JSONString = JSONLines.join('\n');
-    worldEntries.forEach(e => {
-        if (e["keys"].includes('.') && !e["keys"].includes('#')) {
-            e["keys"].split(',').some(keyword => {
-                if (JSONString.toLowerCase().includes(keyword.toLowerCase()) && !text.includes(e["entry"])) {
+    worldEntries.forEach(e =>
+    {
+        if (e["keys"].includes('.') && !e["keys"].includes('#'))
+        {
+            e["keys"].split(',').some(keyword =>
+            {
+                if (JSONString.toLowerCase().includes(keyword.toLowerCase()) && !text.includes(e["entry"]))
+                {
 
 
-                    if (info.memoryLength + contextMemoryLength + e["entry"].length <= info.maxChars / 2) {
-                        spliceMemory(memory.split('\n').length, e["entry"]); return true;
+                    if (info.memoryLength + contextMemoryLength + e["entry"].length <= info.maxChars / 2)
+                    {
+                        spliceMemory(memory.split('\n').length, e["entry"]);
+                        return true;
                     }
                 }
             })
         }
     })
 }
-const parseGen = (text) => { state.generate.process = false; const string = fixDepth(`${state.generate.sections.primer}${text}`); const toParse = string.match(/{.*}/); if (toParse) { const obj = JSON.parse(toParse[0]); worldEntriesFromObject(obj, state.generate.root.split(' ')[0]); state.message = `Generated Object for ${state.generate.root} as type ${state.generate.types[0]}\nResult: ${JSON.stringify(obj)}` } else { state.message = `Failed to parse AI Output for Object ${state.generate.root} type ${state.generate.type[0]}` } }
-const parseAsRoot = (text, root) => { const toParse = text.match(/{.*}/g); if (toParse) { toParse.forEach(string => { const obj = JSON.parse(string); worldEntriesFromObject(obj, root); text = text.replace(string, ''); }) } }
-
-// TODO: Consider re-implementation of this ('generateObject'). Might not see a lot of use considering the energy cost and chance of failed outputs.
-const generateObject = (text) => {
-
-    const { root, types } = state.generate;
-    const type = types[0]
-    const getExamples = (obj, types) => { let exampleString = ``; for (const data in obj) { if (types.some(type => obj[data].hasOwnProperty(type))) { const string = JSON.stringify(obj[data], state.settings.globalWhitelist).replace(/\\/g, ''); if (string.length + exampleString.length <= 1000) { exampleString += '\n' + string; } } } return exampleString }
-    const getAbout = (about) => getHistoryString(-100).split('.').filter(sentence => sentence.toLowerCase().includes(about.toLowerCase())).join('.').trim();
-    const createExample = (args) => {
-        const assign = args.map(e => [e, '<value>']);
-        const obj = Object.fromEntries(assign);
-        return JSON.stringify(obj).replace(/\\/g, '');
+const parseGen = (text) =>
+{
+    state.generate.process = false;
+    const string = fixDepth(`${state.generate.sections.primer}${text}`);
+    const toParse = string.match(/{.*}/);
+    if (toParse)
+    {
+        const obj = JSON.parse(toParse[0]);
+        worldEntriesFromObject(obj, state.generate.root.split(' ')[0]);
+        state.message = `Generated Object for ${state.generate.root} as type ${state.generate.types[0]}\nResult: ${JSON.stringify(obj)}`
     }
-
-    state.generate.process = false
-    //const example = createExample(types);
-    const storedContext = text.substring(0, 0.4 * text.length).trim();
-    const objectExamples = getExamples(dataStorage, types);
-    const rootInformation = getAbout(root).slice(-(info.maxChars) - (objectExamples.length - storedContext.length));
-
-    state.generate.sections = {
-        "stored": `${storedContext}`,
-        "examples": `\n--\nObject representation for ${type}s:${objectExamples}`,
-        //"dummy": `\n${example}`,
-        "about": `\n--\nInformation about ${type} ${root}:\n${rootInformation}`,
-        "preprimer": `\n--\nObject representation for ${type} ${root}:`,
-        "primer": `\n{"${type}":"${root}",`
+    else { state.message = `Failed to parse AI Output for Object ${state.generate.root} type ${state.generate.type[0]}` }
+}
+const parseAsRoot = (text, root) =>
+{
+    const toParse = text.match(/{.*}/g);
+    if (toParse)
+    {
+        toParse.forEach(string =>
+        {
+            const obj = JSON.parse(string);
+            worldEntriesFromObject(obj, root);
+            text = text.replace(string, '');
+        })
     }
-    const { stored, examples, dummy, about, preprimer, primer } = state.generate.sections;
-    const buildString = stored + (objectExamples ? examples : '') + (rootInformation ? about : '') + preprimer + primer
-
-    for (section in state.generate.sections) { console.log(`${section} Length: ${state.generate.sections[section].length}`) }
-    console.log(`Final Text: ${buildString.length}`, `Max Text: ${info.maxChars}`)
-
-    return { text: generateObject(text) }
 }
 
+
+
 const getEntryIndex = (keys) => worldEntries.findIndex(e => e["keys"].toLowerCase() == keys.toLowerCase())
-const updateHUD = () => { const { globalWhitelist } = state.settings; state.displayStats.forEach((e, i) => { if (dataStorage.hasOwnProperty(e["key"].trim())) { state.displayStats[i] = { "key": `${e["key"].trim()}`, "value": `${cleanString(JSON.stringify(dataStorage[e["key"].trim()], globalWhitelist)).replace(/\{|\}/g, '')}    ` } } }) }
+const updateHUD = () =>
+{
+    const { globalWhitelist } = state.settings;
+    state.displayStats.forEach((e, i) => { if (dataStorage.hasOwnProperty(e["key"].trim())) { state.displayStats[i] = { "key": `${e["key"].trim()}`, "value": `${cleanString(JSON.stringify(dataStorage[e["key"].trim()], globalWhitelist)).replace(/\{|\}/g, '')}    ` } } })
+}
 state.commandList = {
     set: // Identifier and name of function
     {
@@ -445,20 +538,20 @@ state.commandList = {
         description: "Sets or updates a World Entry's keys and entry to the arguments given in addition to directly updating the object.",
         args: true,
         usage: '<root>.<property> <value>',
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                const keys = args[0].toLowerCase().trim()
-                const setKeys = keys.includes('.') ? keys : `${keys}.`;
-                const setValue = args.slice(1).join(' ');
-                const index = getEntryIndex(setKeys);
+            const keys = args[0].toLowerCase().trim()
+            const setKeys = keys.includes('.') ? keys : `${keys}.`;
+            const setValue = args.slice(1).join(' ');
+            const index = getEntryIndex(setKeys);
 
-                index >= 0 ? updateWorldEntry(index, setKeys, setValue, isNotHidden = true) : addWorldEntry(setKeys, setValue, isNotHidden = true)
+            index >= 0 ? updateWorldEntry(index, setKeys, setValue, isNotHidden = true) : addWorldEntry(setKeys, setValue, isNotHidden = true)
 
-                state.message = `Set ${setKeys} to ${setValue}!`
-                if (state.displayStats) { updateHUD(); }
-                return
-            }
+            state.message = `Set ${setKeys} to ${setValue}!`
+            if (state.displayStats) { updateHUD(); }
+            return
+        }
     },
     get:
     {
@@ -466,17 +559,18 @@ state.commandList = {
         description: "Fetches and displays the properties of an object.",
         args: true,
         usage: '<root> or <root>.<property>',
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                const path = args.join('').toLowerCase().trim();
-                if (dataStorage && dataStorage.hasOwnProperty(args[0].split('.')[0].toLowerCase().trim())) {
-                    state.message = `Data Sheet for ${path}:\n${JSON.stringify(lens(dataStorage, path), null)}`;
-                }
-                else { state.message = `${path} was invalid!` }
-                return
-
+            const path = args.join('').toLowerCase().trim();
+            if (dataStorage && dataStorage.hasOwnProperty(args[0].split('.')[0].toLowerCase().trim()))
+            {
+                state.message = `Data Sheet for ${path}:\n${JSON.stringify(lens(dataStorage, path), null)}`;
             }
+            else { state.message = `${path} was invalid!` }
+            return
+
+        }
 
     },
     delete:
@@ -485,14 +579,14 @@ state.commandList = {
         description: 'Deletes all dot-separated entries that match the provided argument.',
         args: true,
         usage: '<root> or <root>.<path>',
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                const keys = args[0].toLowerCase().trim();
-                const setKeys = keys.includes('.') ? keys : `${keys}.`;
-                worldEntries.filter(e => e["keys"].toLowerCase().startsWith(setKeys)).forEach(e => removeWorldEntry(worldEntries.indexOf(e)))
-                state.message = `Deleted all entries matching: ${keys}`;
-            }
+            const keys = args[0].toLowerCase().trim();
+            const setKeys = keys.includes('.') ? keys : `${keys}.`;
+            worldEntries.filter(e => e["keys"].toLowerCase().startsWith(setKeys)).forEach(e => removeWorldEntry(worldEntries.indexOf(e)))
+            state.message = `Deleted all entries matching: ${keys}`;
+        }
     },
     show:
     {
@@ -500,14 +594,14 @@ state.commandList = {
         description: "Shows entries starting with the provided argument in World Information.",
         args: true,
         usage: '<root> or <root>.<property>',
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                const keys = args[0].toLowerCase()
-                worldEntries.forEach(e => { if (e["keys"].toLowerCase().startsWith(keys)) { e["isNotHidden"] = true; } })
-                state.message = `Showing all entries starting with ${keys} in World Information!`;
-                return
-            }
+            const keys = args[0].toLowerCase()
+            worldEntries.forEach(e => { if (e["keys"].toLowerCase().startsWith(keys)) { e["isNotHidden"] = true; } })
+            state.message = `Showing all entries starting with ${keys} in World Information!`;
+            return
+        }
     },
     hide:
     {
@@ -515,77 +609,39 @@ state.commandList = {
         description: "Hides entries starting with the provided argument in World Information.",
         args: true,
         usage: '<root> or <root>.<property>',
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                const keys = args[0].toLowerCase()
-                worldEntries.forEach(e => { if (e["keys"].toLowerCase().startsWith(keys)) { e["isNotHidden"] = false; } })
-                state.message = `Hiding all entries starting with ${keys} in World Information!`;
-                return
-            }
+            const keys = args[0].toLowerCase()
+            worldEntries.forEach(e => { if (e["keys"].toLowerCase().startsWith(keys)) { e["isNotHidden"] = false; } })
+            state.message = `Hiding all entries starting with ${keys} in World Information!`;
+            return
+        }
     },
     cross:
     {
         name: 'cross',
         description: `Toggles fetching of World Information from JSON Lines: ${state.settings["entriesFromJSON"]}`,
         args: false,
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                state.settings["entriesFromJSON"] = !state.settings["entriesFromJSON"];
-                state.message = `World Information from JSON Lines: ${state.settings["entriesFromJSON"]}`
-                return
-            }
+            state.settings["entriesFromJSON"] = !state.settings["entriesFromJSON"];
+            state.message = `World Information from JSON Lines: ${state.settings["entriesFromJSON"]}`
+            return
+        }
     },
     filter:
     {
         name: 'filter',
         description: `Toggles the filtering of quotation and curly-brackets within JSON lines: ${state.settings["filter"]}\nSaves character count, but may have detrimental effects.`,
         args: false,
-        execute:
-            (args) => {
-                state.settings["filter"] = !state.settings["filter"];
-                state.message = `'"{}' filter set to ${state.settings["filter"]}`
-                return
-            }
-    },
-    gen:
-    {
-        name: 'gen',
-        description: `Generates an Object for the passed <root> by bringing examples matching <type> into context.`,
-        args: true,
-        usage: '<root>|<type>',
-        execute:
-            (args) => {
-
-                if (!args.join(' ').includes('|')) { state.message = `Error: Separator '|' between <root> and <type> not detected.`; return }
-
-
-                //args = args.map(e => e.trim())
-                state.generate.root = args.slice(0, args.indexOf('|')).join(' ');
-                state.generate.types = args.slice(args.indexOf('|') + 1);
-                state.generate.process = true;
-                state.stop = false;
-                return
-
-            }
-    },
-    searchRange:
-    {
-        name: 'searchRange',
-        description: 'Set the search range for attribute conditions - Default (4)\nValid Attributes are: a,d,p,s, and t',
-        args: true,
-        usage: '<Attribute> <Number> e.g /searchRange t 50',
-        execute:
-            (args) => {
-
-                const attribute = args[0].replace(/\[|\]/g, '');
-
-                const value = Number(args.slice(1).join(''))
-                console.log(attribute, value)
-                if (state.settings.ewi.hasOwnProperty(attribute)) { state.settings.ewi[attribute]["range"] = value; state.message = `Search Range of [${attribute}] set to ${value}!` }
-                else { state.message = `[${attribute}] is not configureable for range!` }
-            }
+        execute: (args) =>
+        {
+            state.settings["filter"] = !state.settings["filter"];
+            state.message = `'"{}' filter set to ${state.settings["filter"]}`
+            return
+        }
     },
     from:
     {
@@ -593,14 +649,14 @@ state.commandList = {
         description: 'Creates an Object with the given root from the passed JSON- line.',
         args: 'true',
         usage: '<root> <JSON- Line/Object>',
-        execute:
-            (args) => {
-                const obj = args.slice(1).join(' ')
-                const root = args[0]
-                parseAsRoot(obj, root)
-                state.message = `Created Object '${root}' from ${obj}!`
+        execute: (args) =>
+        {
+            const obj = args.slice(1).join(' ')
+            const root = args[0]
+            parseAsRoot(obj, root)
+            state.message = `Created Object '${root}' from ${obj}!`
 
-            }
+        }
     },
     hud:
     {
@@ -608,22 +664,22 @@ state.commandList = {
         description: "Tracks the Object in the HUD",
         args: 'true',
         usage: '<root>',
-        execute:
-            (args) => {
+        execute: (args) =>
+        {
 
-                if (!state.displayStats) { state.displayStats = [] }
-                //getGlobalWhitelist(getHistoryString(-10).slice(-info.maxChars))
-                const { globalWhitelist } = state.settings;
-                const root = args[0].trim();
-                const index = state.displayStats.findIndex(e => e["key"].trim() == root)
+            if (!state.displayStats) { state.displayStats = [] }
+            //getGlobalWhitelist(getHistoryString(-10).slice(-info.maxChars))
+            const { globalWhitelist } = state.settings;
+            const root = args[0].trim();
+            const index = state.displayStats.findIndex(e => e["key"].trim() == root)
 
-                if (dataStorage.hasOwnProperty(root)) {
-                    const object = { "key": root, "value": `${cleanString(JSON.stringify(dataStorage[root], globalWhitelist).replace(/\{|\}/g, '')).replace(/\{|\}/g, '')}    ` }
-                    if (index >= 0) { state.displayStats.splice(index, 1) }
-                    else { state.displayStats.push(object) }
-                }
-
+            if (dataStorage.hasOwnProperty(root))
+            {
+                const object = { "key": root, "value": `${cleanString(JSON.stringify(dataStorage[root], globalWhitelist).replace(/\{|\}/g, '')).replace(/\{|\}/g, '')}    ` }
+                if (index >= 0) { state.displayStats.splice(index, 1) }
+                else { state.displayStats.push(object) }
             }
+
+        }
     }
 };
-

--- a/AID-Script-Examples/EWIJSON/release/shared.js
+++ b/AID-Script-Examples/EWIJSON/release/shared.js
@@ -443,7 +443,7 @@ const sortObjects = (list) =>
     .forEach(e => execAttributes(e["matches"][0], e["entry"], getAttributes(e["matches"][1])))
 
 }
-
+// TEST
 const crossLines = () =>
 {
     const JSONLines = lines.filter(line => /\[\{.*\}\]/.test(line));

--- a/AID-Script-Examples/EWIJSON/release/shared.js
+++ b/AID-Script-Examples/EWIJSON/release/shared.js
@@ -24,8 +24,9 @@ const Expressions = {
     "EWI": /#\[.*\]$/
 }
 
-const track = (value, attribute) => { if (!Tracker.hasOwnProperty(attribute)) {Tracker[attribute] = [];} const index = Tracker[attribute].findIndex(x => x.includes(value)); index >= 0 ? Tracker[attribute][index].push(value) : Tracker[attribute].push([value]); const result = Tracker[attribute].find(e => e.includes(value)).length; return result > 1 ? result - 1 : 0};
-const Tracker = { }
+const track = (value, attribute) => { if (!Tracker.hasOwnProperty(attribute)) { Tracker[attribute] = []; } const index = Tracker[attribute].findIndex(x => x.includes(value));
+    index >= 0 ? Tracker[attribute][index].push(value) : Tracker[attribute].push([value]); const result = Tracker[attribute].find(e => e.includes(value)).length; return result > 1 ? result - 1 : 0 };
+const Tracker = {}
 
 // Config for consistency.
 state.config = {
@@ -282,7 +283,7 @@ const globalReplacer = () =>
                 else if (wildcards.some(e => { if (display.split('.')[e[1]] == e[0]) { current = e[0]; return true } }))
                 {
                     const array = display.split('.');
-                    paths.push(array);
+                    paths.push([array, 0]);
                 }
                 else if (display.startsWith(synonymsPath) && Boolean(value) && Boolean(match[0])) { paths.push([display.split('.'), lines.join('\n').lastIndexOf(match[0][match[0].length - 1])]); }
 
@@ -291,6 +292,7 @@ const globalReplacer = () =>
         }
     }
 
+    console.log(paths)
     JSON.stringify(dataStorage, replacer(function(key, value, path) { return value; }));
     return [...new Set([...whitelist, ...paths.sort((a, b) => a[1] - b[1]).map(e => e[0]).flat()])].filter(e => !internalPaths.includes(e)).map(e => e.replace(wildcardPath, ''))
 }

--- a/AID-Script-Examples/EWIJSON/release/shared.js
+++ b/AID-Script-Examples/EWIJSON/release/shared.js
@@ -115,7 +115,7 @@ const regExMatch = (keys) =>
         {
 
             const length = getAttributes(line.slice(/#\[.*\]/.test(line) ? line.lastIndexOf('#') : 0)).find(e => e[0] == 'l')
-            const string = lines.slice(length ? -length[1] : 0).join('\n');
+            const string = getHistoryString(length ? -length[1] : 0).slice(-info.maxChars);
             const expressions = line.slice(0, /#\[.*\]/.test(line) ? line.lastIndexOf('#') : line.length).split(/(?<!\\),/g);
             if (expressions.every(exp => { const regEx = new RegExp(exp.replace(/\\/g, ''), 'i'); return regEx.test(string); }))
             {

--- a/AID-Script-Examples/EWIJSON/release/shared.js
+++ b/AID-Script-Examples/EWIJSON/release/shared.js
@@ -24,7 +24,9 @@ const Expressions = {
     "EWI": /#\[.*\]$/
 }
 
-const Tracker = {}
+const track = (value, attribute) => { if (!Tracker.hasOwnProperty(attribute)) {Tracker[attribute] = [];} const index = Tracker[attribute].findIndex(x => x.includes(value)); index >= 0 ? Tracker[attribute][index].push(value) : Tracker[attribute].push([value]); const result = Tracker[attribute].find(e => e.includes(value)).length; return result > 1 ? result - 1 : 0};
+const Tracker = { }
+
 // Config for consistency.
 state.config = {
     prefix: /^\n> You \/|^\n> You say "\/|^\/|^\n\//gi,
@@ -170,7 +172,8 @@ const addMemoryEntry = (entry, value = 0) =>
 const addTrailingEntry = (entry, value = 0) =>
 {
     let finalIndex = -1;
-    copyLines.forEach((line, i) => { if (line.includes(entry["keys"][0])) { finalIndex = i; } })
+    console.log(entry["keys"][0])
+    lines.forEach((line, i) => { if (line.includes(entry["keys"][0])) { finalIndex = i; } })
     if (finalIndex >= 0)
     {
         spliceContext((finalIndex) - value, entry["entry"])

--- a/AID-Script-Examples/EWIJSON/release/shared.js
+++ b/AID-Script-Examples/EWIJSON/release/shared.js
@@ -450,7 +450,7 @@ const crossLines = () =>
     const JSONString = JSONLines.join('\n');
     worldEntries.forEach(e =>
     {
-        if (e["keys"].includes('.') && !e["keys"].includes('#'))
+        if (!e["keys"].includes('.')) // Handle regular entries - EWI likely fails test.
         {
             e["keys"].split(',').some(keyword =>
             {
@@ -460,11 +460,22 @@ const crossLines = () =>
 
                     if (info.memoryLength + contextMemoryLength + e["entry"].length <= info.maxChars / 2)
                     {
-                        spliceMemory(memory.split('\n').length, e["entry"]);
+                        spliceMemory(memoryLines.length - 1, e["entry"]);
                         return true;
                     }
                 }
             })
+        }
+        if (Expressions["EWI"].test(e["keys"])) // Handle EWI entries.
+        {
+            if (regExMatch(e["keys"] && !text.includes(e["entry"])))
+            {
+                if (info.memoryLength + contextMemoryLength + e["entry"].length <= info.maxChars / 2)
+                    {
+                        spliceMemory(memoryLines.length - 1, e["entry"]);
+                        return true;
+                    }
+            }
         }
     })
 }


### PR DESCRIPTION
Background changes and implementation of the `[l]` (L) attribute - handles the length of actions or lines that conditions should match within.
All insertions are done in order of most-recent mention, but the `[t]` attribute lacks proper adjustments to enforce it.
Contextual properties on Objects are also sorted in order of most-recent mention instead of the previous creation order sorting.

Bugfix: `crossLines()` should function on both normal and attribute entries as it does individual checks for each.
Refactor: `regExMatch` is passed the keys to check while string is handed internally and checks for the `[l]` attribute to determine lines - absence is full length. `regExMatch` returns the result of the check in addition to what `keys` were checked to maintain support for multi-line conditionals.
Refactor: Attributes can be obtained via the `getAttributes(string)` function that returns an two-dimensional `Array` of `[[attribute, value]]` or `undefined` if there's no presence of `#[]` in the `string`.